### PR TITLE
fromBeBytes and fromLeBytes changed to static method

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ const c = new Uint32(0x1234_5678n);
 console.log(c.toBeBytes()); // [18, 52, 86, 120]([0x12, 0x34, 0x56, 0x78])
 console.log(c.toLeBytes()); // [120, 86, 52, 18]([0x78, 0x56, 0x34, 0x12])
 
-const d = Uint32.prototype.fromBeBytes(
+const d = Uint32.fromBeBytes(
   new Uint8Array([0x12, 0x34, 0x56, 0x78]),
 );
-const e = Uint32.prototype.fromLeBytes(
+const e = Uint32.fromLeBytes(
   new Uint8Array([0x12, 0x34, 0x56, 0x78]),
 );
 
@@ -93,10 +93,10 @@ TypedNumeric.prototype.rotateRight(TypedNumeric)
 // e.g. OK: new Uint8Array(4) => Uint32, ERROR: new Uint8Array(3) => Uint32
 
 // from big endian bytes
-TypedNumeric.prototype.fromBeBytes(TypedNumeric)
+TypedNumeric.fromBeBytes(TypedNumeric)
 
 // from little endian bytes
-TypedNumeric.prototype.fromLeBytes(TypedNumeric)
+TypedNumeric.fromLeBytes(TypedNumeric)
 
 // Create Uint8Array from TypedNumeric
 

--- a/example.ts
+++ b/example.ts
@@ -13,10 +13,10 @@ const c = new Uint32(0x1234_5678n);
 console.log(c.toBeBytes()); // [18, 52, 86, 120]([0x12, 0x34, 0x56, 0x78])
 console.log(c.toLeBytes()); // [120, 86, 52, 18]([0x78, 0x56, 0x34, 0x12])
 
-const d = Uint32.prototype.fromBeBytes(
+const d = Uint32.fromBeBytes(
   new Uint8Array([0x12, 0x34, 0x56, 0x78]),
 );
-const e = Uint32.prototype.fromLeBytes(
+const e = Uint32.fromLeBytes(
   new Uint8Array([0x12, 0x34, 0x56, 0x78]),
 );
 

--- a/src/int128.ts
+++ b/src/int128.ts
@@ -242,7 +242,7 @@ export class Int128 implements Numeric<Int128> {
         (this.#value << ((BIT_LENGTH - n) % BIT_LENGTH)),
     );
   }
-  fromBeBytes(bytes: Uint8Array): Int128 {
+  static fromBeBytes(bytes: Uint8Array): Int128 {
     if (bytes.length === 16) {
       return new Int128(
         ((BigInt(bytes[0]) << 120n) & 0xFF000000_00000000_00000000_00000000n) |
@@ -267,7 +267,7 @@ export class Int128 implements Numeric<Int128> {
       "Invalid Length Error: Expected Uint8Array.prototype.length is 16",
     );
   }
-  fromLeBytes(bytes: Uint8Array): Int128 {
+  static fromLeBytes(bytes: Uint8Array): Int128 {
     if (bytes.length === 16) {
       return new Int128(
         ((BigInt(bytes[15]) << 120n) & 0xFF000000_00000000_00000000_00000000n) |

--- a/src/int128_test.ts
+++ b/src/int128_test.ts
@@ -309,7 +309,7 @@ Deno.test("Int128", () => {
   );
   // fromBeBytes()
   assertEquals(
-    Int128.prototype.fromBeBytes(
+    Int128.fromBeBytes(
       Uint8Array.from([
         0x12,
         0x34,
@@ -332,7 +332,7 @@ Deno.test("Int128", () => {
     new Int128(0x12345678_90123456_78901234_56789012n).value(),
   );
   assertEquals(
-    Int128.prototype.fromBeBytes(
+    Int128.fromBeBytes(
       new Uint8Array(
         [
           0x7F,
@@ -357,16 +357,16 @@ Deno.test("Int128", () => {
     Int128.prototype.max(),
   );
   assertEquals(
-    Int128.prototype.fromBeBytes(new Uint8Array(16)).value(),
+    Int128.fromBeBytes(new Uint8Array(16)).value(),
     0n,
   );
   assertThrows((): void => {
     // Invalid Length
-    Int128.prototype.fromBeBytes(new Uint8Array(17));
+    Int128.fromBeBytes(new Uint8Array(17));
   });
   // fromLeBytes()
   assertEquals(
-    Int128.prototype.fromLeBytes(
+    Int128.fromLeBytes(
       Uint8Array.from([
         0x12,
         0x34,
@@ -389,7 +389,7 @@ Deno.test("Int128", () => {
     new Int128(0x12907856_34129078_56341290_78563412n).value(),
   );
   assertEquals(
-    Int128.prototype.fromLeBytes(
+    Int128.fromLeBytes(
       new Uint8Array(
         [
           0xFF,
@@ -414,12 +414,12 @@ Deno.test("Int128", () => {
     Int128.prototype.max(),
   );
   assertEquals(
-    Int128.prototype.fromLeBytes(new Uint8Array(16)).value(),
+    Int128.fromLeBytes(new Uint8Array(16)).value(),
     0n,
   );
   assertThrows((): void => {
     // Invalid Length
-    Int128.prototype.fromLeBytes(new Uint8Array(17));
+    Int128.fromLeBytes(new Uint8Array(17));
   });
   // toBeBytes()
   assertEquals(

--- a/src/int16.ts
+++ b/src/int16.ts
@@ -175,7 +175,7 @@ export class Int16 implements Numeric<Int16> {
         (this.#value << ((BIT_LENGTH - n) % BIT_LENGTH)),
     );
   }
-  fromBeBytes(bytes: Uint8Array): Int16 {
+  static fromBeBytes(bytes: Uint8Array): Int16 {
     if (bytes.length === 2) {
       return new Int16(
         ((bytes[0] << 8) & 0xFF00) |
@@ -186,7 +186,7 @@ export class Int16 implements Numeric<Int16> {
       "Invalid Length Error: Expected Uint8Array.prototype.length is 2",
     );
   }
-  fromLeBytes(bytes: Uint8Array): Int16 {
+  static fromLeBytes(bytes: Uint8Array): Int16 {
     if (bytes.length === 2) {
       return new Int16(
         ((bytes[1] << 8) & 0xFF00) |

--- a/src/int16_test.ts
+++ b/src/int16_test.ts
@@ -125,37 +125,37 @@ Deno.test("Int16", () => {
   assertEquals(new Int16(0x1234).rotateRight(64).value(), 0x1234);
   // fromBeBytes()
   assertEquals(
-    Int16.prototype.fromBeBytes(Uint8Array.from([0x12, 0x34])).value(),
+    Int16.fromBeBytes(Uint8Array.from([0x12, 0x34])).value(),
     new Int16(0x1234).value(),
   );
   assertEquals(
-    Int16.prototype.fromBeBytes(new Uint8Array([0x7F, 0xFF])).value(),
+    Int16.fromBeBytes(new Uint8Array([0x7F, 0xFF])).value(),
     Int16.prototype.max(),
   );
   assertEquals(
-    Int16.prototype.fromBeBytes(new Uint8Array(2)).value(),
+    Int16.fromBeBytes(new Uint8Array(2)).value(),
     0,
   );
   assertThrows((): void => {
     // Invalid Length
-    Int16.prototype.fromBeBytes(new Uint8Array(3));
+    Int16.fromBeBytes(new Uint8Array(3));
   });
   // fromLeBytes()
   assertEquals(
-    Int16.prototype.fromLeBytes(Uint8Array.from([0x12, 0x34])).value(),
+    Int16.fromLeBytes(Uint8Array.from([0x12, 0x34])).value(),
     new Int16(0x3412).value(),
   );
   assertEquals(
-    Int16.prototype.fromLeBytes(new Uint8Array([0xFF, 0x7F])).value(),
+    Int16.fromLeBytes(new Uint8Array([0xFF, 0x7F])).value(),
     Int16.prototype.max(),
   );
   assertEquals(
-    Int16.prototype.fromLeBytes(new Uint8Array(2)).value(),
+    Int16.fromLeBytes(new Uint8Array(2)).value(),
     0,
   );
   assertThrows((): void => {
     // Invalid Length
-    Int16.prototype.fromLeBytes(new Uint8Array(3));
+    Int16.fromLeBytes(new Uint8Array(3));
   });
   // toBeBytes()
   assertEquals(new Int16(0x1234).toBeBytes(), new Uint8Array([0x12, 0x34]));

--- a/src/int256.ts
+++ b/src/int256.ts
@@ -326,7 +326,7 @@ export class Int256 implements Numeric<Int256> {
         (this.#value << ((BIT_LENGTH - n) % BIT_LENGTH)),
     );
   }
-  fromBeBytes(bytes: Uint8Array): Int256 {
+  static fromBeBytes(bytes: Uint8Array): Int256 {
     if (bytes.length === 32) {
       return new Int256(
         ((BigInt(bytes[0]) << 248n) &
@@ -384,7 +384,7 @@ export class Int256 implements Numeric<Int256> {
       "Invalid Length Error: Expected Uint8Array.prototype.length is 32",
     );
   }
-  fromLeBytes(bytes: Uint8Array): Int256 {
+  static fromLeBytes(bytes: Uint8Array): Int256 {
     if (bytes.length === 32) {
       return new Int256(
         ((BigInt(bytes[31]) << 248n) &

--- a/src/int256_test.ts
+++ b/src/int256_test.ts
@@ -435,7 +435,7 @@ Deno.test("Int256", () => {
   );
   // fromBeBytes()
   assertEquals(
-    Int256.prototype.fromBeBytes(
+    Int256.fromBeBytes(
       Uint8Array.from([
         0x12,
         0x34,
@@ -476,7 +476,7 @@ Deno.test("Int256", () => {
     ).value(),
   );
   assertEquals(
-    Int256.prototype.fromBeBytes(
+    Int256.fromBeBytes(
       new Uint8Array(
         [
           0x7F,
@@ -517,16 +517,16 @@ Deno.test("Int256", () => {
     Int256.prototype.max(),
   );
   assertEquals(
-    Int256.prototype.fromBeBytes(new Uint8Array(32)).value(),
+    Int256.fromBeBytes(new Uint8Array(32)).value(),
     0n,
   );
   assertThrows((): void => {
     // Invalid Length
-    Int256.prototype.fromBeBytes(new Uint8Array(33));
+    Int256.fromBeBytes(new Uint8Array(33));
   });
   // fromLeBytes()
   assertEquals(
-    Int256.prototype.fromLeBytes(
+    Int256.fromLeBytes(
       Uint8Array.from([
         0x12,
         0x34,
@@ -567,7 +567,7 @@ Deno.test("Int256", () => {
     ).value(),
   );
   assertEquals(
-    Int256.prototype.fromLeBytes(
+    Int256.fromLeBytes(
       new Uint8Array(
         [
           0xFF,
@@ -608,12 +608,12 @@ Deno.test("Int256", () => {
     Int256.prototype.max(),
   );
   assertEquals(
-    Int256.prototype.fromLeBytes(new Uint8Array(32)).value(),
+    Int256.fromLeBytes(new Uint8Array(32)).value(),
     0n,
   );
   assertThrows((): void => {
     // Invalid Length
-    Int256.prototype.fromLeBytes(new Uint8Array(33));
+    Int256.fromLeBytes(new Uint8Array(33));
   });
   // toBeBytes()
   assertEquals(

--- a/src/int32.ts
+++ b/src/int32.ts
@@ -184,7 +184,7 @@ export class Int32 implements Numeric<Int32> {
         (this.#value << ((BIT_LENGTH - n) % BIT_LENGTH)),
     );
   }
-  fromBeBytes(bytes: Uint8Array): Int32 {
+  static fromBeBytes(bytes: Uint8Array): Int32 {
     if (bytes.length === 4) {
       return new Int32(
         ((BigInt(bytes[0]) << 24n) & 0xFF00_0000n) |
@@ -197,7 +197,7 @@ export class Int32 implements Numeric<Int32> {
       "Invalid Length Error: Expected Uint8Array.prototype.length is 4",
     );
   }
-  fromLeBytes(bytes: Uint8Array): Int32 {
+  static fromLeBytes(bytes: Uint8Array): Int32 {
     if (bytes.length === 4) {
       return new Int32(
         ((BigInt(bytes[3]) << 24n) & 0xFF00_0000n) |

--- a/src/int32_test.ts
+++ b/src/int32_test.ts
@@ -144,41 +144,41 @@ Deno.test("Int32", () => {
   assertEquals(new Int32(0x1234_5678n).rotateRight(128n).value(), 0x1234_5678n);
   // fromBeBytes()
   assertEquals(
-    Int32.prototype.fromBeBytes(Uint8Array.from([0x12, 0x34, 0x56, 0x78]))
+    Int32.fromBeBytes(Uint8Array.from([0x12, 0x34, 0x56, 0x78]))
       .value(),
     new Int32(0x1234_5678n).value(),
   );
   assertEquals(
-    Int32.prototype.fromBeBytes(new Uint8Array([0x7F, 0xFF, 0xFF, 0xFF]))
+    Int32.fromBeBytes(new Uint8Array([0x7F, 0xFF, 0xFF, 0xFF]))
       .value(),
     Int32.prototype.max(),
   );
   assertEquals(
-    Int32.prototype.fromBeBytes(new Uint8Array(4)).value(),
+    Int32.fromBeBytes(new Uint8Array(4)).value(),
     0n,
   );
   assertThrows((): void => {
     // Invalid Length
-    Int32.prototype.fromBeBytes(new Uint8Array(5));
+    Int32.fromBeBytes(new Uint8Array(5));
   });
   // fromLeBytes()
   assertEquals(
-    Int32.prototype.fromLeBytes(Uint8Array.from([0x12, 0x34, 0x56, 0x78]))
+    Int32.fromLeBytes(Uint8Array.from([0x12, 0x34, 0x56, 0x78]))
       .value(),
     new Int32(0x7856_3412n).value(),
   );
   assertEquals(
-    Int32.prototype.fromLeBytes(new Uint8Array([0xFF, 0xFF, 0xFF, 0x7F]))
+    Int32.fromLeBytes(new Uint8Array([0xFF, 0xFF, 0xFF, 0x7F]))
       .value(),
     Int32.prototype.max(),
   );
   assertEquals(
-    Int32.prototype.fromLeBytes(new Uint8Array(4)).value(),
+    Int32.fromLeBytes(new Uint8Array(4)).value(),
     0n,
   );
   assertThrows((): void => {
     // Invalid Length
-    Int32.prototype.fromLeBytes(new Uint8Array(5));
+    Int32.fromLeBytes(new Uint8Array(5));
   });
   // toBeBytes()
   assertEquals(

--- a/src/int64.ts
+++ b/src/int64.ts
@@ -202,7 +202,7 @@ export class Int64 implements Numeric<Int64> {
         (this.#value << ((BIT_LENGTH - n) % BIT_LENGTH)),
     );
   }
-  fromBeBytes(bytes: Uint8Array): Int64 {
+  static fromBeBytes(bytes: Uint8Array): Int64 {
     if (bytes.length === 8) {
       return new Int64(
         ((BigInt(bytes[0]) << 56n) & 0xFF000000_00000000n) |
@@ -219,7 +219,7 @@ export class Int64 implements Numeric<Int64> {
       "Invalid Length Error: Expected Uint8Array.prototype.length is 8",
     );
   }
-  fromLeBytes(bytes: Uint8Array): Int64 {
+  static fromLeBytes(bytes: Uint8Array): Int64 {
     if (bytes.length === 8) {
       return new Int64(
         ((BigInt(bytes[7]) << 56n) & 0xFF000000_00000000n) |

--- a/src/int64_test.ts
+++ b/src/int64_test.ts
@@ -233,45 +233,45 @@ Deno.test("Int64", () => {
   );
   // fromBeBytes()
   assertEquals(
-    Int64.prototype.fromBeBytes(
+    Int64.fromBeBytes(
       Uint8Array.from([0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56]),
     ).value(),
     new Int64(0x12345678_90123456n).value(),
   );
   assertEquals(
-    Int64.prototype.fromBeBytes(
+    Int64.fromBeBytes(
       new Uint8Array([0x7F, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]),
     ).value(),
     Int64.prototype.max(),
   );
   assertEquals(
-    Int64.prototype.fromBeBytes(new Uint8Array(8)).value(),
+    Int64.fromBeBytes(new Uint8Array(8)).value(),
     0n,
   );
   assertThrows((): void => {
     // Invalid Length
-    Int64.prototype.fromBeBytes(new Uint8Array(9));
+    Int64.fromBeBytes(new Uint8Array(9));
   });
   // fromLeBytes()
   assertEquals(
-    Int64.prototype.fromLeBytes(
+    Int64.fromLeBytes(
       Uint8Array.from([0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56]),
     ).value(),
     new Int64(0x56341290_78563412n).value(),
   );
   assertEquals(
-    Int64.prototype.fromLeBytes(
+    Int64.fromLeBytes(
       new Uint8Array([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x7F]),
     ).value(),
     Int64.prototype.max(),
   );
   assertEquals(
-    Int64.prototype.fromLeBytes(new Uint8Array(8)).value(),
+    Int64.fromLeBytes(new Uint8Array(8)).value(),
     0n,
   );
   assertThrows((): void => {
     // Invalid Length
-    Int64.prototype.fromLeBytes(new Uint8Array(9));
+    Int64.fromLeBytes(new Uint8Array(9));
   });
   // toBeBytes()
   assertEquals(

--- a/src/int8.ts
+++ b/src/int8.ts
@@ -173,7 +173,7 @@ export class Int8 implements Numeric<Int8> {
         (this.#value << ((BIT_LENGTH - n) % BIT_LENGTH)),
     );
   }
-  fromBeBytes(bytes: Uint8Array): Int8 {
+  static fromBeBytes(bytes: Uint8Array): Int8 {
     if (bytes.length === (BIT_LENGTH / 8)) {
       return new Int8(bytes[0]);
     }
@@ -181,7 +181,7 @@ export class Int8 implements Numeric<Int8> {
       "Invalid Length Error: Expected Uint8Array.prototype.length is 1",
     );
   }
-  fromLeBytes(bytes: Uint8Array): Int8 {
+  static fromLeBytes(bytes: Uint8Array): Int8 {
     if (bytes.length === (BIT_LENGTH / 8)) {
       return new Int8(bytes[0]);
     }

--- a/src/int8_test.ts
+++ b/src/int8_test.ts
@@ -124,37 +124,37 @@ Deno.test("Int8", () => {
   assertEquals(new Int8(0x12).rotateRight(16).value(), 0x12);
   // fromBeBytes()
   assertEquals(
-    Int8.prototype.fromBeBytes(Uint8Array.from([0x12])).value(),
+    Int8.fromBeBytes(Uint8Array.from([0x12])).value(),
     new Int8(0x12).value(),
   );
   assertEquals(
-    Int8.prototype.fromBeBytes(new Uint8Array(1).fill(0x7F)).value(),
+    Int8.fromBeBytes(new Uint8Array(1).fill(0x7F)).value(),
     Int8.prototype.max(),
   );
   assertEquals(
-    Int8.prototype.fromBeBytes(new Uint8Array(1)).value(),
+    Int8.fromBeBytes(new Uint8Array(1)).value(),
     0,
   );
   assertThrows((): void => {
     // Invalid Length
-    Int8.prototype.fromBeBytes(new Uint8Array(2));
+    Int8.fromBeBytes(new Uint8Array(2));
   });
   // fromLeBytes()
   assertEquals(
-    Int8.prototype.fromLeBytes(Uint8Array.from([0x12])).value(),
+    Int8.fromLeBytes(Uint8Array.from([0x12])).value(),
     new Int8(0x12).value(),
   );
   assertEquals(
-    Int8.prototype.fromLeBytes(new Uint8Array(1).fill(0x7F)).value(),
+    Int8.fromLeBytes(new Uint8Array(1).fill(0x7F)).value(),
     Int8.prototype.max(),
   );
   assertEquals(
-    Int8.prototype.fromLeBytes(new Uint8Array(1)).value(),
+    Int8.fromLeBytes(new Uint8Array(1)).value(),
     0,
   );
   assertThrows((): void => {
     // Invalid Length
-    Int8.prototype.fromLeBytes(new Uint8Array(2));
+    Int8.fromLeBytes(new Uint8Array(2));
   });
   // toBeBytes()
   assertEquals(new Int8(0x12).toBeBytes(), new Uint8Array([0x12]));

--- a/src/mod.ts
+++ b/src/mod.ts
@@ -35,9 +35,9 @@ export interface Numeric<T> {
   rotateRight(n: number | bigint): T;
   // Create T from Uint8Array
   // Uint8Array to T
-  fromBeBytes(bytes: Uint8Array): T;
+  // static fromBeBytes(bytes: Uint8Array): T;
   // Uint8Array to T
-  fromLeBytes(bytes: Uint8Array): T;
+  // static fromLeBytes(bytes: Uint8Array): T;
   // Crate Uint8Array
   // T to big endian Uint8Array
   toBeBytes(): Uint8Array;

--- a/src/uint128.ts
+++ b/src/uint128.ts
@@ -66,7 +66,7 @@ export class Uint128 implements Numeric<Uint128> {
         (this.#value << ((BIT_LENGTH - n) % BIT_LENGTH)),
     );
   }
-  fromBeBytes(bytes: Uint8Array): Uint128 {
+  static fromBeBytes(bytes: Uint8Array): Uint128 {
     if (bytes.length === 16) {
       return new Uint128(
         ((BigInt(bytes[0]) << 120n) & 0xFF000000_00000000_00000000_00000000n) |
@@ -91,7 +91,7 @@ export class Uint128 implements Numeric<Uint128> {
       "Invalid Length Error: Expected Uint8Array.prototype.length is 16",
     );
   }
-  fromLeBytes(bytes: Uint8Array): Uint128 {
+  static fromLeBytes(bytes: Uint8Array): Uint128 {
     if (bytes.length === 16) {
       return new Uint128(
         ((BigInt(bytes[15]) << 120n) & 0xFF000000_00000000_00000000_00000000n) |

--- a/src/uint128_test.ts
+++ b/src/uint128_test.ts
@@ -195,7 +195,7 @@ Deno.test("Uint128", () => {
   );
   // fromBeBytes()
   assertEquals(
-    Uint128.prototype.fromBeBytes(
+    Uint128.fromBeBytes(
       Uint8Array.from(
         [
           0x12,
@@ -220,20 +220,20 @@ Deno.test("Uint128", () => {
     new Uint128(0x12345678_90123456_78901234_56789012n).value(),
   );
   assertEquals(
-    Uint128.prototype.fromBeBytes(new Uint8Array(16).fill(0xFF)).value(),
+    Uint128.fromBeBytes(new Uint8Array(16).fill(0xFF)).value(),
     Uint128.prototype.max(),
   );
   assertEquals(
-    Uint128.prototype.fromBeBytes(new Uint8Array(16)).value(),
+    Uint128.fromBeBytes(new Uint8Array(16)).value(),
     Uint128.prototype.min(),
   );
   assertThrows((): void => {
     // Invalid Length
-    Uint128.prototype.fromBeBytes(new Uint8Array(17));
+    Uint128.fromBeBytes(new Uint8Array(17));
   });
   // fromLeBytes()
   assertEquals(
-    Uint128.prototype.fromLeBytes(
+    Uint128.fromLeBytes(
       Uint8Array.from(
         [
           0x12,
@@ -258,16 +258,16 @@ Deno.test("Uint128", () => {
     new Uint128(0x12907856_34129078_56341290_78563412n).value(),
   );
   assertEquals(
-    Uint128.prototype.fromLeBytes(new Uint8Array(16).fill(0xFF)).value(),
+    Uint128.fromLeBytes(new Uint8Array(16).fill(0xFF)).value(),
     Uint128.prototype.max(),
   );
   assertEquals(
-    Uint128.prototype.fromLeBytes(new Uint8Array(16)).value(),
+    Uint128.fromLeBytes(new Uint8Array(16)).value(),
     Uint128.prototype.min(),
   );
   assertThrows((): void => {
     // Invalid Length
-    Uint128.prototype.fromLeBytes(new Uint8Array(17));
+    Uint128.fromLeBytes(new Uint8Array(17));
   });
   // toBeBytes()
   assertEquals(

--- a/src/uint16.ts
+++ b/src/uint16.ts
@@ -72,7 +72,7 @@ export class Uint16 implements Numeric<Uint16> {
         (this.#value << ((BIT_LENGTH - n) % BIT_LENGTH)),
     );
   }
-  fromBeBytes(bytes: Uint8Array): Uint16 {
+  static fromBeBytes(bytes: Uint8Array): Uint16 {
     if (bytes.length === (BIT_LENGTH / 8)) {
       return new Uint16(
         ((bytes[0] << 8) & 0xFF00) |
@@ -83,7 +83,7 @@ export class Uint16 implements Numeric<Uint16> {
       "Invalid Length Error: Expected Uint8Array.prototype.length is 2",
     );
   }
-  fromLeBytes(bytes: Uint8Array): Uint16 {
+  static fromLeBytes(bytes: Uint8Array): Uint16 {
     if (bytes.length === (BIT_LENGTH / 8)) {
       return new Uint16(
         ((bytes[1] << 8) & 0xFF00) |

--- a/src/uint16_test.ts
+++ b/src/uint16_test.ts
@@ -78,37 +78,37 @@ Deno.test("Uint16", () => {
   assertEquals(new Uint16(0x1234).rotateRight(32).value(), 0x1234);
   // fromBeBytes()
   assertEquals(
-    Uint16.prototype.fromBeBytes(Uint8Array.from([0x12, 0x34])).value(),
+    Uint16.fromBeBytes(Uint8Array.from([0x12, 0x34])).value(),
     new Uint16(0x1234).value(),
   );
   assertEquals(
-    Uint16.prototype.fromBeBytes(new Uint8Array(2).fill(0xFF)).value(),
+    Uint16.fromBeBytes(new Uint8Array(2).fill(0xFF)).value(),
     Uint16.prototype.max(),
   );
   assertEquals(
-    Uint16.prototype.fromBeBytes(new Uint8Array(2)).value(),
+    Uint16.fromBeBytes(new Uint8Array(2)).value(),
     Uint16.prototype.min(),
   );
   assertThrows((): void => {
     // Invalid Length
-    Uint16.prototype.fromBeBytes(new Uint8Array(3));
+    Uint16.fromBeBytes(new Uint8Array(3));
   });
   // fromLeBytes()
   assertEquals(
-    Uint16.prototype.fromLeBytes(Uint8Array.from([0x12, 0x34])).value(),
+    Uint16.fromLeBytes(Uint8Array.from([0x12, 0x34])).value(),
     new Uint16(0x3412).value(),
   );
   assertEquals(
-    Uint16.prototype.fromLeBytes(new Uint8Array(2).fill(0xFF)).value(),
+    Uint16.fromLeBytes(new Uint8Array(2).fill(0xFF)).value(),
     Uint16.prototype.max(),
   );
   assertEquals(
-    Uint16.prototype.fromLeBytes(new Uint8Array(2)).value(),
+    Uint16.fromLeBytes(new Uint8Array(2)).value(),
     Uint16.prototype.min(),
   );
   assertThrows((): void => {
     // Invalid Length
-    Uint16.prototype.fromLeBytes(new Uint8Array(3));
+    Uint16.fromLeBytes(new Uint8Array(3));
   });
   // toBeBytes()
   assertEquals(new Uint16(0x1234).toBeBytes(), new Uint8Array([0x12, 0x34]));

--- a/src/uint256.ts
+++ b/src/uint256.ts
@@ -67,7 +67,7 @@ export class Uint256 implements Numeric<Uint256> {
         (this.#value << ((BIT_LENGTH - n) % BIT_LENGTH)),
     );
   }
-  fromBeBytes(bytes: Uint8Array): Uint256 {
+  static fromBeBytes(bytes: Uint8Array): Uint256 {
     if (bytes.length === 32) {
       return new Uint256(
         ((BigInt(bytes[0]) << 248n) &
@@ -125,7 +125,7 @@ export class Uint256 implements Numeric<Uint256> {
       "Invalid Length Error: Expected Uint8Array.prototype.length is 32",
     );
   }
-  fromLeBytes(bytes: Uint8Array): Uint256 {
+  static fromLeBytes(bytes: Uint8Array): Uint256 {
     if (bytes.length === 32) {
       return new Uint256(
         ((BigInt(bytes[31]) << 248n) &

--- a/src/uint256_test.ts
+++ b/src/uint256_test.ts
@@ -236,7 +236,7 @@ Deno.test("Uint256", () => {
   );
   // fromBeBytes()
   assertEquals(
-    Uint256.prototype.fromBeBytes(
+    Uint256.fromBeBytes(
       Uint8Array.from(
         [
           0x12,
@@ -279,20 +279,20 @@ Deno.test("Uint256", () => {
     ).value(),
   );
   assertEquals(
-    Uint256.prototype.fromBeBytes(new Uint8Array(32).fill(0xFF)).value(),
+    Uint256.fromBeBytes(new Uint8Array(32).fill(0xFF)).value(),
     Uint256.prototype.max(),
   );
   assertEquals(
-    Uint256.prototype.fromBeBytes(new Uint8Array(32)).value(),
+    Uint256.fromBeBytes(new Uint8Array(32)).value(),
     Uint256.prototype.min(),
   );
   assertThrows((): void => {
     // Invalid Length
-    Uint256.prototype.fromBeBytes(new Uint8Array(33));
+    Uint256.fromBeBytes(new Uint8Array(33));
   });
   // fromLeBytes()
   assertEquals(
-    Uint256.prototype.fromLeBytes(
+    Uint256.fromLeBytes(
       Uint8Array.from(
         [
           0x12,
@@ -335,16 +335,16 @@ Deno.test("Uint256", () => {
     ).value(),
   );
   assertEquals(
-    Uint256.prototype.fromLeBytes(new Uint8Array(32).fill(0xFF)).value(),
+    Uint256.fromLeBytes(new Uint8Array(32).fill(0xFF)).value(),
     Uint256.prototype.max(),
   );
   assertEquals(
-    Uint256.prototype.fromLeBytes(new Uint8Array(32)).value(),
+    Uint256.fromLeBytes(new Uint8Array(32)).value(),
     Uint256.prototype.min(),
   );
   assertThrows((): void => {
     // Invalid Length
-    Uint256.prototype.fromLeBytes(new Uint8Array(33));
+    Uint256.fromLeBytes(new Uint8Array(33));
   });
   // toBeBytes()
   assertEquals(

--- a/src/uint32.ts
+++ b/src/uint32.ts
@@ -66,7 +66,7 @@ export class Uint32 implements Numeric<Uint32> {
         (this.#value << ((BIT_LENGTH - n) % BIT_LENGTH)),
     );
   }
-  fromBeBytes(bytes: Uint8Array): Uint32 {
+  static fromBeBytes(bytes: Uint8Array): Uint32 {
     if (bytes.length === 4) {
       return new Uint32(
         ((BigInt(bytes[0]) << 24n) & 0xFF00_0000n) |
@@ -79,7 +79,7 @@ export class Uint32 implements Numeric<Uint32> {
       "Invalid Length Error: Expected Uint8Array.prototype.length is 4",
     );
   }
-  fromLeBytes(bytes: Uint8Array): Uint32 {
+  static fromLeBytes(bytes: Uint8Array): Uint32 {
     if (bytes.length === 4) {
       return new Uint32(
         ((BigInt(bytes[3]) << 24n) & 0xFF00_0000n) |

--- a/src/uint32_test.ts
+++ b/src/uint32_test.ts
@@ -109,39 +109,39 @@ Deno.test("Uint32", () => {
   assertEquals(new Uint32(0x1234_5678n).rotateRight(64n).value(), 0x1234_5678n);
   // fromBeBytes()
   assertEquals(
-    Uint32.prototype.fromBeBytes(Uint8Array.from([0x12, 0x34, 0x56, 0x78]))
+    Uint32.fromBeBytes(Uint8Array.from([0x12, 0x34, 0x56, 0x78]))
       .value(),
     new Uint32(0x1234_5678n).value(),
   );
   assertEquals(
-    Uint32.prototype.fromBeBytes(new Uint8Array(4).fill(0xFF)).value(),
+    Uint32.fromBeBytes(new Uint8Array(4).fill(0xFF)).value(),
     Uint32.prototype.max(),
   );
   assertEquals(
-    Uint32.prototype.fromBeBytes(new Uint8Array(4)).value(),
+    Uint32.fromBeBytes(new Uint8Array(4)).value(),
     Uint32.prototype.min(),
   );
   assertThrows((): void => {
     // Invalid Length
-    Uint32.prototype.fromBeBytes(new Uint8Array(5));
+    Uint32.fromBeBytes(new Uint8Array(5));
   });
   // fromLeBytes()
   assertEquals(
-    Uint32.prototype.fromLeBytes(Uint8Array.from([0x12, 0x34, 0x56, 0x78]))
+    Uint32.fromLeBytes(Uint8Array.from([0x12, 0x34, 0x56, 0x78]))
       .value(),
     new Uint32(0x7856_3412n).value(),
   );
   assertEquals(
-    Uint32.prototype.fromLeBytes(new Uint8Array(4).fill(0xFF)).value(),
+    Uint32.fromLeBytes(new Uint8Array(4).fill(0xFF)).value(),
     Uint32.prototype.max(),
   );
   assertEquals(
-    Uint32.prototype.fromLeBytes(new Uint8Array(4)).value(),
+    Uint32.fromLeBytes(new Uint8Array(4)).value(),
     Uint32.prototype.min(),
   );
   assertThrows((): void => {
     // Invalid Length
-    Uint32.prototype.fromLeBytes(new Uint8Array(5));
+    Uint32.fromLeBytes(new Uint8Array(5));
   });
   // toBeBytes()
   assertEquals(

--- a/src/uint64.ts
+++ b/src/uint64.ts
@@ -66,7 +66,7 @@ export class Uint64 implements Numeric<Uint64> {
         (this.#value << ((BIT_LENGTH - n) % BIT_LENGTH)),
     );
   }
-  fromBeBytes(bytes: Uint8Array): Uint64 {
+  static fromBeBytes(bytes: Uint8Array): Uint64 {
     if (bytes.length === 8) {
       return new Uint64(
         ((BigInt(bytes[0]) << 56n) & 0xFF000000_00000000n) |
@@ -83,7 +83,7 @@ export class Uint64 implements Numeric<Uint64> {
       "Invalid Length Error: Expected Uint8Array.prototype.length is 8",
     );
   }
-  fromLeBytes(bytes: Uint8Array): Uint64 {
+  static fromLeBytes(bytes: Uint8Array): Uint64 {
     if (bytes.length === 8) {
       return new Uint64(
         ((BigInt(bytes[7]) << 56n) & 0xFF000000_00000000n) |

--- a/src/uint64_test.ts
+++ b/src/uint64_test.ts
@@ -168,41 +168,41 @@ Deno.test("Uint64", () => {
   );
   // fromBeBytes()
   assertEquals(
-    Uint64.prototype.fromBeBytes(
+    Uint64.fromBeBytes(
       Uint8Array.from([0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56]),
     ).value(),
     new Uint64(0x12345678_90123456n).value(),
   );
   assertEquals(
-    Uint64.prototype.fromBeBytes(new Uint8Array(8).fill(0xFF)).value(),
+    Uint64.fromBeBytes(new Uint8Array(8).fill(0xFF)).value(),
     Uint64.prototype.max(),
   );
   assertEquals(
-    Uint64.prototype.fromBeBytes(new Uint8Array(8)).value(),
+    Uint64.fromBeBytes(new Uint8Array(8)).value(),
     Uint64.prototype.min(),
   );
   assertThrows((): void => {
     // Invalid Length
-    Uint64.prototype.fromBeBytes(new Uint8Array(9));
+    Uint64.fromBeBytes(new Uint8Array(9));
   });
   // fromLeBytes()
   assertEquals(
-    Uint64.prototype.fromLeBytes(
+    Uint64.fromLeBytes(
       Uint8Array.from([0x12, 0x34, 0x56, 0x78, 0x90, 0x12, 0x34, 0x56]),
     ).value(),
     new Uint64(0x56341290_78563412n).value(),
   );
   assertEquals(
-    Uint64.prototype.fromLeBytes(new Uint8Array(8).fill(0xFF)).value(),
+    Uint64.fromLeBytes(new Uint8Array(8).fill(0xFF)).value(),
     Uint64.prototype.max(),
   );
   assertEquals(
-    Uint64.prototype.fromLeBytes(new Uint8Array(8)).value(),
+    Uint64.fromLeBytes(new Uint8Array(8)).value(),
     Uint64.prototype.min(),
   );
   assertThrows((): void => {
     // Invalid Length
-    Uint64.prototype.fromLeBytes(new Uint8Array(9));
+    Uint64.fromLeBytes(new Uint8Array(9));
   });
   // toBeBytes()
   assertEquals(

--- a/src/uint8.ts
+++ b/src/uint8.ts
@@ -72,7 +72,7 @@ export class Uint8 implements Numeric<Uint8> {
         (this.#value << ((BIT_LENGTH - n) % BIT_LENGTH)),
     );
   }
-  fromBeBytes(bytes: Uint8Array): Uint8 {
+  static fromBeBytes(bytes: Uint8Array): Uint8 {
     if (bytes.length === (BIT_LENGTH / 8)) {
       return new Uint8(bytes[0]);
     }
@@ -80,7 +80,7 @@ export class Uint8 implements Numeric<Uint8> {
       "Invalid Length Error: Expected Uint8Array.prototype.length is 1",
     );
   }
-  fromLeBytes(bytes: Uint8Array): Uint8 {
+  static fromLeBytes(bytes: Uint8Array): Uint8 {
     if (bytes.length === (BIT_LENGTH / 8)) {
       return new Uint8(bytes[0]);
     }

--- a/src/uint8_test.ts
+++ b/src/uint8_test.ts
@@ -78,37 +78,37 @@ Deno.test("Uint8", () => {
   assertEquals(new Uint8(0x12).rotateRight(16).value(), 0x12);
   // fromBeBytes()
   assertEquals(
-    Uint8.prototype.fromBeBytes(Uint8Array.from([0x12])).value(),
+    Uint8.fromBeBytes(Uint8Array.from([0x12])).value(),
     new Uint8(0x12).value(),
   );
   assertEquals(
-    Uint8.prototype.fromBeBytes(new Uint8Array(1).fill(0xFF)).value(),
+    Uint8.fromBeBytes(new Uint8Array(1).fill(0xFF)).value(),
     Uint8.prototype.max(),
   );
   assertEquals(
-    Uint8.prototype.fromBeBytes(new Uint8Array(1)).value(),
+    Uint8.fromBeBytes(new Uint8Array(1)).value(),
     Uint8.prototype.min(),
   );
   assertThrows((): void => {
     // Invalid Length
-    Uint8.prototype.fromBeBytes(new Uint8Array(2));
+    Uint8.fromBeBytes(new Uint8Array(2));
   });
   // fromLeBytes()
   assertEquals(
-    Uint8.prototype.fromLeBytes(Uint8Array.from([0x12])).value(),
+    Uint8.fromLeBytes(Uint8Array.from([0x12])).value(),
     new Uint8(0x12).value(),
   );
   assertEquals(
-    Uint8.prototype.fromLeBytes(new Uint8Array(1).fill(0xFF)).value(),
+    Uint8.fromLeBytes(new Uint8Array(1).fill(0xFF)).value(),
     Uint8.prototype.max(),
   );
   assertEquals(
-    Uint8.prototype.fromLeBytes(new Uint8Array(1)).value(),
+    Uint8.fromLeBytes(new Uint8Array(1)).value(),
     Uint8.prototype.min(),
   );
   assertThrows((): void => {
     // Invalid Length
-    Uint8.prototype.fromLeBytes(new Uint8Array(2));
+    Uint8.fromLeBytes(new Uint8Array(2));
   });
   // toBeBytes()
   assertEquals(new Uint8(0x12).toBeBytes(), new Uint8Array([0x12]));


### PR DESCRIPTION
* T.prototype.fromBeBytes() => T.fromBeBytes()
* T.prototype.fromLeBytes() => T.fromLeBytes()

Numeric<T>の上記2つのメソッドをコメントアウト。共通クラスへの移行を検討。

Thank you!!!!!!!!! @AgataYMGT